### PR TITLE
AWS IAM Identity Center (successor to AWS SSO)

### DIFF
--- a/content/Introduction/_index.en.md
+++ b/content/Introduction/_index.en.md
@@ -8,7 +8,7 @@ pre = ""
 # LEARNING OBJECTIVES
 Today we are going to learn the following topics:
 
-- How to integrate Okta in AWS SSO 
+- How to integrate Okta in AWS IAM Identity Center (successor to AWS SSO) 
 - How to push groups and users from Okta to AWS 
 - How to assign permissions in AWS to the pushed users
 
@@ -18,10 +18,14 @@ This workshop is broken into the sections listed below. Estimated time for compl
 
 - Create Accounts for AWS and Okta to use for this Workshop (0-30 min)
 - Create Groups in Okta (10 min)
-- Integrate Okta & AWS SSO (15 min)
+- Integrate Okta & AWS IAM Identity Center (successor to AWS SSO) (15 min)
 - Assign Groups & Provision (10 min)
 - Create & Assign permission sets on AWS (15 min)
 - Test (5 min)
 - Cleanup (5 min)
 
-This workshop is focused on the initial integration of Okta and AWS SSO. The section "Additional Use Cases" is optional and will extend the demo environment or describes some more advanced topics. Please find the ones relevant for you and try them out.
+This workshop is focused on the initial integration of Okta and AWS IAM Identity Center (successor to AWS SSO). The section "Additional Use Cases" is optional and will extend the demo environment or describes some more advanced topics. Please find the ones relevant for you and try them out.
+
+{{% notice info %}}
+AWS SSO was recently renamed to AWS IAM Identity Center. The Workshop will still use AWS SSO until the new name has been adopted on all ends. 
+{{% /notice %}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,14 +1,16 @@
 +++
-title = "Okta AWS SSO integration Workshop"
+title = "Okta AWS IAM Identity Center (successor to AWS SSO) integration Workshop"
 chapter = true
 weight = 1
 +++
 
 ![Overview](/images/okta_logo.png)
 
-In this Workshop you will learn how to integrate Okta with AWS SSO.
+Last Updated August 2nd 2022.
 
-Okta provides Single Sign-On with adaptive MFA and advanced user life-cycle management for AWS SSO.
+In this Workshop you will learn how to integrate Okta with AWS IAM Identity Center (successor to AWS SSO).
+
+Okta provides Single Sign-On with adaptive MFA and advanced user life-cycle management for AWS IAM Identity Center (successor to AWS SSO).
 
 The goal of the workshop is to build an end-to-end demo environment from creating free Okta and AWS accounts, configuring the integration, creating some test groups and testing it at the end. The last chapter covers some more advanced use cases.
 


### PR DESCRIPTION
Updated first pages to reflect name change AWS IAM Identity Center (successor to AWS SSO)

See: https://aws.amazon.com/blogs/security/scale-your-workforce-access-management-with-aws-iam-identity-center-previously-known-as-aws-sso/